### PR TITLE
Expose `site.json`

### DIFF
--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -1305,4 +1305,12 @@ class DiscourseAPI {
 
 		return $res;
 	}
+
+    /**
+     * @throws Exception
+     */
+    public function getSite(): stdClass
+    {
+        return $this->_getRequest('/site.json');
+    }
 }

--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -21,6 +21,7 @@ namespace pnoeric;
 use CURLFile;
 use DateTime;
 use Exception;
+use RuntimeException;
 use stdClass;
 
 use function is_int;
@@ -1311,6 +1312,12 @@ class DiscourseAPI {
      */
     public function getSite(): stdClass
     {
-        return $this->_getRequest('/site.json');
+        $result = $this->_getRequest('/site.json');
+
+        if (!is_object($result) || !isset($result->apiresult)) {
+            throw new RuntimeException('Failed fetching site info');
+        }
+
+        return $result->apiresult;
     }
 }


### PR DESCRIPTION
Exposes https://docs.discourse.org/#tag/Site through API. Useful for various things, but in my particular use case I was looking for the _full_ list of categories (whereas `getCategories` only returns top level categories).